### PR TITLE
remove ldap pretask, tasks and vars

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -20,17 +20,6 @@
       with_items:
         - mencoder # For the 'make movie' script
 
-    - name: Prerequisites for ldap
-      become: yes
-      yum:
-        name: "{{ item }}"
-        state: present
-      with_items:
-        - openldap-clients
-        - python-virtualenv
-        - gcc
-        - python-ldap
-
     # Since Nginx isn't installed until later the directories are created in advance
     - name: Create nginx include directories
       become: yes
@@ -272,22 +261,6 @@
         group: "omero-server"
         force: yes
 
-    - name: Create a directory for ldap scripts
-      become: yes
-      file:
-        path: /home/ldap
-        state: directory
-        mode: 0755
-        recurse: yes
-
-    - name: Download the ldap scripts
-      become: yes
-      get_url:
-        url: https://raw.githubusercontent.com/openmicroscopy/apacheds-docker/{{ apache_docker_release }}/bin/ldapmanager
-        dest: /home/ldap/ldapmanager
-        mode: 0755
-        force: yes
-
     - name: Add DropBox folder for trainer-1
       become: yes
       file:
@@ -313,16 +286,6 @@
         regexp: "{{ omero_server_system_managedrepo_group }}"
         insertbefore: BOF
         line: "+:{{ omero_server_system_managedrepo_group }}:ALL"
-
-    - name: Run docker for ldap
-      become: yes
-      docker_container:
-        image: openmicroscopy/apacheds:{{ apache_docker_release }}
-        name: ldap
-        published_ports:
-        - "10389:10389"
-        state: started
-        restart_policy: always
 
     - name: Run docker for omero-ms-zarr
       become: yes
@@ -470,7 +433,6 @@
     apache_docker_release: "{{ apache_docker_release_override | default('0.6.0') }}"
     omero_ms_zarr_release: "{{ omero_ms_zarr_release_override | default('latest') }}"
     minio_docker_release: "{{ minio_docker_release_override | default('RELEASE.2020-11-25T22-36-25Z') }}"
-    ldap_password: "{{ ldap_password_override | default ('secret') }}"
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"
       omero.certificates.owner: "/C=UK/ST=Scotland/L=Dundee/O=OME"
@@ -488,18 +450,6 @@
       # This password doesn't need to be secret
       omero.glacier2.IceSSL.Password: secret
       omero.fs.repo.path: "%user%_%userId%/%thread%//%year%-%month%/%day%/%time%"
-      omero.ldap.config: "true"
-      omero.ldap.urls: "ldap://localhost:10389"
-      omero.ldap.base: "dc=openmicroscopy,dc=org"
-      omero.ldap.group_filter: "(objectClass=groupOfUniqueNames)"
-      omero.ldap.group_mapping: "name=cn"
-      omero.ldap.new_user_group: "MyData"
-      omero.ldap.new_user_group_owner: "(owner=@{dn})"
-      omero.ldap.password: "{{ ldap_password }}"
-      omero.ldap.sync_on_login: "true"
-      omero.ldap.user_filter: "(objectClass=person)"
-      omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"
-      omero.ldap.username: "uid=admin,ou=system"
       omero.server.nodedescriptors: "master:Blitz-0,Indexer-0,Processor-0,Storm,Tables-0"
 
     external_nic: "{{ ansible_default_ipv4.interface }}"


### PR DESCRIPTION
Removing LDAP from the playbook as this should be only a access publicly. Only the admin should have access to the server.